### PR TITLE
docs: mention installation for Arch Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@
     `cat-latte-lavender`, `cat-frappe-green`, `cat-macchiato-red`...
 6. Visit [Papirus-folders](https://github.com/PapirusDevelopmentTeam/papirus-folders) to learn more about this script
 
+### For Arch Linux Users
+
+With your favorite AUR helper, install with:
+
+```sh
+yay -S papirus-folders-catppuccin-git
+```
+
+then you could run `papirus-folders -h` to see all available command. Bash & ZSH completions are included.
+
 &nbsp;
 
 ## 💝 Thanks to


### PR DESCRIPTION
AUR package is [available](https://aur.archlinux.org/packages/papirus-folders-catppuccin-git) for Arch Linux users.